### PR TITLE
Add Jobright to manual job sources

### DIFF
--- a/components/EditModal.tsx
+++ b/components/EditModal.tsx
@@ -389,6 +389,7 @@ const enumOptions: Record<string, { value: any; label: string }[]> = {
     { value: "job_board", label: "Job Board" },
     { value: "scraper", label: "Scraper" },
     { value: "hiring.cafe", label: "Hiring Cafe" },
+    { value: "jobright.ai", label: "Jobright" },
     { value: "trueup.io", label: "TrueUp.io" },
     { value: "interview_modal", label: "Interview Modal" },
     { value: "email_bot_llm_local", label: "Email Bot LLM Local" },


### PR DESCRIPTION
Overview
This PR updates the UI components to recognize Jobright as a valid job source within the WBL platform.

Changes Made
components/EditModal.tsx: Added `{ value: "jobright.ai", label: "Jobright" }` to the manual job source dropdown to allow admins to properly categorize job listings.

Note: The Candidate Dashboard link generation requires no changes. The Jobright pipeline natively stores the original ATS link (Greenhouse, Workday, LinkedIn) inside `job_url`, which the dashboard already natively falls back to.
