### PR TITLE
Refactor Course Material UI: rename to Must Watch, remove unused categories, and lock navigation to ML.

### DIFF
--- a/app/avatar/training/course_material/page.tsx
+++ b/app/avatar/training/course_material/page.tsx
@@ -45,11 +45,9 @@ interface MaterialFormData {
 
 const TYPE_MAPPING = {
   P: "Presentations",
-  Y: "Must See Youtube Videos",
+  Y: "Must Watch",
   C: "Cheatsheets",
   SG: "Study Guides",
-  D: "Diagrams",
-  S: "Softwares",
   I: "Interactive Visual Explainers",
   B: "Books",
   N: "Newsletters",
@@ -59,11 +57,9 @@ const TYPE_MAPPING = {
 
 const TYPE_OPTIONS = [
   { value: "P", label: "Presentations" },
-  { value: "Y", label: "Must See Youtube Videos" },
+  { value: "Y", label: "Must Watch" },
   { value: "C", label: "Cheatsheets" },
   { value: "SG", label: "Study Guides" },
-  { value: "D", label: "Diagrams" },
-  { value: "S", label: "Softwares" },
   { value: "I", label: "Interactive Visual Explainers" },
   { value: "B", label: "Books" },
   { value: "N", label: "Newsletters" },

--- a/app/presentation/page.tsx
+++ b/app/presentation/page.tsx
@@ -21,14 +21,12 @@ import {
 
 type ComponentType =
   | "Presentations"
-  | "Must See Youtube Videos"
+  | "Must Watch"
   | "Cheatsheets"
   | "Study Guides"
-  | "Diagrams"
   | "Interactive Visual Explainers"
   | "Newsletters"
   | "Books"
-  | "Softwares"
   | "Assignments";
 
 export default function PresentationPage() {
@@ -43,8 +41,8 @@ export default function PresentationPage() {
   const buttons = [
     { type: "Presentations", label: "Presentations", icon: Presentation },
     {
-      type: "Must See Youtube Videos",
-      label: "Must See Youtube Videos",
+      type: "Must Watch",
+      label: "Must Watch",
       icon: Youtube,
     },
     { type: "Cheatsheets", label: "Cheatsheets", icon: FileText },
@@ -55,8 +53,6 @@ export default function PresentationPage() {
       icon: Sparkles,
     },
     { type: "Books", label: "O'Reilly Books", icon: Library },
-    { type: "Diagrams", label: "Diagrams", icon: Network },
-    { type: "Softwares", label: "Softwares", icon: Cpu },
     { type: "Newsletters", label: "Newsletters", icon: Mail },
     { type: "Assignments", label: "Assignments", icon: ClipboardList },
   ];
@@ -77,7 +73,11 @@ export default function PresentationPage() {
         if (!valid) {
           router.push("/login");
         } else {
-          const selectedCourse = searchParams.get("course") || "ML";
+          let selectedCourse = searchParams.get("course") || "ML";
+          if (selectedCourse.toUpperCase() === "UI" || selectedCourse.toUpperCase() === "QA") {
+            selectedCourse = "ML";
+            router.push("/presentation?course=ML");
+          }
           setCourse(selectedCourse);
           setLoading(false);
         }
@@ -128,10 +128,9 @@ export default function PresentationPage() {
                     className={`mb-1 w-full rounded-md px-4 font-bold text-black
                       hover:bg-gradient-to-tl hover:from-primary hover:to-blue-300
                       sm:w-44
-                      ${
-                        isActive
-                          ? "border-2 border-blue-600 bg-gradient-to-br from-primary to-blue-400 text-white shadow-lg"
-                          : "bg-gradient-to-br from-primary to-blue-300"
+                      ${isActive
+                        ? "border-2 border-blue-600 bg-gradient-to-br from-primary to-blue-400 text-white shadow-lg"
+                        : "bg-gradient-to-br from-primary to-blue-300"
                       }`}
                   >
                     <div className="flex h-[56px] items-center gap-3">

--- a/components/Common/CourseNavigation.tsx
+++ b/components/Common/CourseNavigation.tsx
@@ -12,8 +12,6 @@ const CourseNavigation = () => {
 
   const courseOptions = [
     { short: "ML", full: "Machine Learning" },
-    { short: "UI", full: "UI Fullstack" },
-    { short: "QA", full: "Quality Engineer" },
   ];
  
   

--- a/components/Common/resourcesTable.tsx
+++ b/components/Common/resourcesTable.tsx
@@ -5,14 +5,12 @@ import { toast } from "sonner";
 
 type ComponentType =
   | "Presentations"
-  | "Must See Youtube Videos"
+  | "Must Watch"
   | "Cheatsheets"
   | "Study Guides"
-  | "Diagrams"
   | "Interactive Visual Explainers"
   | "Newsletters"
   | "Books"
-  | "Softwares"
   | "Assignments";
 
 const fetchPresentationData = async (course: string, type: ComponentType) => {
@@ -189,9 +187,8 @@ const ResourcesTable = ({
           {data.map((subject: any, index: number) => (
             <tr
               key={subject.id || index}
-              className={`hover:bg-gray-200 dark:hover:bg-blue-500 ${
-                index % 2 === 0 ? "bg-gray-100 dark:bg-transparent" : "bg-gray-200 dark:bg-transparent"
-              }`}
+              className={`hover:bg-gray-200 dark:hover:bg-blue-500 ${index % 2 === 0 ? "bg-gray-100 dark:bg-transparent" : "bg-gray-200 dark:bg-transparent"
+                }`}
             >
               <td className="border border-primary px-4 py-2 text-center text-black dark:border-blue-900 dark:text-white">
                 {index + 1}

--- a/components/EditModal.tsx
+++ b/components/EditModal.tsx
@@ -576,11 +576,9 @@ const genericStatusOptions = [
 
 const materialTypeOptions = [
   { value: "P", label: "Presentations" },
-  { value: "Y", label: "Must See Youtube Videos" },
+  { value: "Y", label: "Must Watch" },
   { value: "C", label: "Cheatsheets" },
   { value: "SG", label: "Study Guides" },
-  { value: "D", label: "Diagrams" },
-  { value: "S", label: "Softwares" },
   { value: "I", label: "Interactive Visual Explainers" },
   { value: "B", label: "Books" },
   { value: "N", label: "Newsletters" },

--- a/components/Header/menuData.tsx
+++ b/components/Header/menuData.tsx
@@ -26,7 +26,7 @@ const menuData: Menu[] = [
       },
       {
         id: 42,
-        title: "Presentation ",
+        title: "Course Material",
         path: "/presentation",
         newTab: false,
       },

--- a/components/ViewModal.tsx
+++ b/components/ViewModal.tsx
@@ -894,11 +894,9 @@ export function ViewModal({ isOpen, onClose, data, currentIndex = 0, onNavigate,
 
     const typeMap: Record<string, string> = {
       'P': 'Presentations',
-      'Y': 'Must See Youtube Videos',
+      'Y': 'Must Watch',
       'C': 'Cheatsheets',
       'SG': 'Study Guides',
-      'D': 'Diagrams',
-      'S': 'Softwares',
       'I': 'Interactive Visual Explainers',
       'B': 'Books',
       'N': 'Newsletters',


### PR DESCRIPTION
Update Course Material navigation and categories

Renamed  "Must See Youtube Videos" to "Must Watch" across all components
Changed header menu title from "Presentation" to "Course Material"
Removed deprecated "Diagrams" and "Softwares" categories from UI and modals
Restrict CourseNavigation dropdown to only show "Machine Learning" and deleted Courses "UI Full Stack and Quality Engineer"
Add route guard to redirect manual UI/QA URL queries back to ML
