### PR TITLE
fixed deduplicate Internal session types in the recording dropdown 

### DIFF
--- a/components/Recording/SessionComp.tsx
+++ b/components/Recording/SessionComp.tsx
@@ -64,16 +64,18 @@ const normalizeType = (type: string) => {
 };
 
 const sortSessionTypes = (types: SessionType[]) => {
-  return types
-    .map((t) => ({ ...t, type: normalizeType(t.type) }))
-    .sort((a, b) => {
-      const indexA = desiredOrder.indexOf(a.type);
-      const indexB = desiredOrder.indexOf(b.type);
-      if (indexA === -1 && indexB === -1) return a.type.localeCompare(b.type); // both unknown
-      if (indexA === -1) return 1; // put unknowns at the end
-      if (indexB === -1) return -1;
-      return indexA - indexB;
-    });
+  const uniqueTypes = Array.from(
+    new Set(types.map((t) => normalizeType(t.type)))
+  ).map((t) => ({ type: t }));
+
+  return uniqueTypes.sort((a, b) => {
+    const indexA = desiredOrder.indexOf(a.type);
+    const indexB = desiredOrder.indexOf(b.type);
+    if (indexA === -1 && indexB === -1) return a.type.localeCompare(b.type); // both unknown
+    if (indexA === -1) return 1; // put unknowns at the end
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+  });
 };
 
 const SessionComp = () => {


### PR DESCRIPTION
[Fixed an issue in the recording session dropdown where duplicate session types (like 'Internal Sessions') were appearing. two times](https://github.com/WhiteboxHub/wbl-frontend/pull/682)